### PR TITLE
Cleaning Accounts App

### DIFF
--- a/bug-track/accounts/templates/accounts/authenticated.html
+++ b/bug-track/accounts/templates/accounts/authenticated.html
@@ -1,7 +1,0 @@
-{% extends "base.html" %}
-
-{% block title %}authenticated{% endblock title %}
-
-{% block content %}
-    {{ user.is_authenticated }}
-{% endblock content %}

--- a/bug-track/accounts/templates/accounts/login.html
+++ b/bug-track/accounts/templates/accounts/login.html
@@ -1,37 +1,59 @@
 {% extends "base.html" %}
 
-{% block title %}login{% endblock title %}
+{% block title %}account | login{% endblock title %}
+
+{% load widget_tweaks %}
 
 {% block content %}
+    <form method="post">
+        {% csrf_token %}
+        <div class="row mt-4">
+            <div class="col">
+                <h1>Login</h1>
+            </div>
+        </div>
+        <hr/>
+        {% if form.errors %}
+            <div class="row">
+                <div class="col">
+                    <p>Your username and password didn't match. Please try again.</p>
+                </div>
+            </div>
+        {% endif %}
+        {% if next %}
+            {% if user.is_authenticated %}
+                <div class="row">
+                    <div class="col">
+                        <p>Your account doesn't have access to this page.
+                         To proceed, please login with an account that has access.</p>
+                    </div>
+                </div>
+            {% else %}
+                <div class="row">
+                    <div class="col">
+                        <p>Please login to see this page.</p>
+                    </div>
+                </div>
+            {% endif %}
+        {% endif %}
+        <div class="form-group">
+            <label for="id_username">{{ form.username.label }}</label>
+            {{ form.username | add_class:"form-control" }}
+        </div>
+        <div class="form-group">
+            <label for="id_password">{{ form.password.label }}</label>
+            {{ form.password | add_class:"form-control" }}
+        </div>
+        <div class="row">
+            <div class="col">
+                <input class="btn btn-primary float-right" type="submit" value="Login" />
+            </div>
+        </div>
+        <input type="hidden" name="next" value="{{ next }}" />
+    </form>
 
-{% if form.errors %}
-<p>Your username and password didn't match. Please try again.</p>
-{% endif %}
 
-{% if next %}
-    {% if user.is_authenticated %}
-    <p>Your account doesn't have access to this page. To proceed,
-    please login with an account that has access.</p>
-    {% else %}
-    <p>Please login to see this page.</p>
-    {% endif %}
-{% endif %}
 
-<form method="post">
-{% csrf_token %}
-<table>
-<tr>
-    <td>{{ form.username.label_tag }}</td>
-    <td>{{ form.username }}</td>
-</tr>
-<tr>
-    <td>{{ form.password.label_tag }}</td>
-    <td>{{ form.password }}</td>
-</tr>
-</table>
 
-<input type="submit" value="login" />
-<input type="hidden" name="next" value="{{ next }}" />
-</form>
 
 {% endblock %}

--- a/bug-track/accounts/templates/accounts/logout.html
+++ b/bug-track/accounts/templates/accounts/logout.html
@@ -1,7 +1,17 @@
 {% extends "base.html" %}
 
-{% block title %}logged out{% endblock title %}
+{% block title %}account | logout{% endblock title %}
 
 {% block content %}
-    <p>{{ title }}</p>
+    <div class="row mt-4">
+        <div class="col">
+            <h1>Logout</h1>
+        </div>
+    </div>
+    <hr/>
+    <div class="row">
+        <div class="col">
+            <p>You have been logged out from your session</p>
+        </div>
+    </div>
 {% endblock content %}

--- a/bug-track/accounts/templates/accounts/password_change_done.html
+++ b/bug-track/accounts/templates/accounts/password_change_done.html
@@ -1,7 +1,0 @@
-{% extends "base.html" %}
-
-{% block title %}password changed{% endblock title %}
-
-{% block content %}
-    <p>password changed</p>
-{% endblock content %}

--- a/bug-track/accounts/templates/accounts/password_change_form.html
+++ b/bug-track/accounts/templates/accounts/password_change_form.html
@@ -1,11 +1,34 @@
 {% extends "base.html" %}
 
-{% block title %}change password{% endblock title %}
+{% block title %}account | change password{% endblock title %}
+
+{% load widget_tweaks %}
 
 {% block content %}
 <form method="post">
     {% csrf_token %}
-    {{ form.as_p }}
-    <input type="submit" value="submit" />
+    <div class="row mt-4">
+        <div class="col">
+            <h1>Change Password</h1>
+        </div>
+    </div>
+    <hr/>
+    <div class="form-group">
+        <label for="">{{ form.old_password.label }}</label>
+        {{ form.old_password | add_class:"form-control" }}
+    </div>
+    <div class="form-group">
+        <label for="">{{ form.new_password1.label }}</label>
+        {{ form.new_password1 | add_class:"form-control" }}
+    </div>
+    <div class="form-group">
+        <label for="">{{ form.new_password2.label }}</label>
+        {{ form.new_password2 | add_class:"form-control" }}
+    </div>
+    <div class="row">
+        <div class="col">
+            <input class="btn btn-primary float-right" type="submit" value="Submit" />
+        </div>
+    </div>
 </form>
 {% endblock content %}

--- a/bug-track/accounts/templates/accounts/password_reset_complete.html
+++ b/bug-track/accounts/templates/accounts/password_reset_complete.html
@@ -4,5 +4,5 @@
 
 {% block content %}
     <p>password reset successfully</p>
-    <p><a href="{% url 'auth_login' %}">Login</a></p>
+    <p><a href="{% url 'accounts:login' %}">Login</a></p>
 {% endblock content %}

--- a/bug-track/accounts/templates/accounts/profile.html
+++ b/bug-track/accounts/templates/accounts/profile.html
@@ -2,4 +2,5 @@
 {% block title %} profile{% endblock title %}
 {% block content %}
 <p>{{ user.username }}</p>
+<P>{{ user.is_authenticated }}</P>
 {% endblock content %}

--- a/bug-track/accounts/urls.py
+++ b/bug-track/accounts/urls.py
@@ -1,19 +1,56 @@
-from accounts.views import login_view, register_view, logout_view, authenticated_view
+from accounts.views import (
+    Register, Profile, ResetDone, ResetComplete
+)
 from django.urls import path
 from django.contrib.auth import views as auth_views
-from .forms import UserLoginForm, UserRegisterForm
-from django.conf import settings
+from .forms import UserLoginForm
 from django.urls import reverse_lazy
 
 app_name = "accounts"
 
 urlpatterns = [
-    # path('login/', login_view, name="login"),
-    path('login/', auth_views.LoginView.as_view(template_name="accounts/login.html", authentication_form=UserLoginForm), name="login"),
-    path('logout/', auth_views.LogoutView.as_view(template_name="accounts/logout.html"), name="logout"),
-    path('authenticated/', authenticated_view, name="authenticated"),
-    path('password_change/', auth_views.PasswordChangeView.as_view(template_name="accounts/password_change_form.html", success_url=reverse_lazy("accounts:authenticated")), name="password-change"),
-    path('password_reset/', auth_views.PasswordResetView.as_view(template_name="accounts/password_reset_form.html", email_template_name="accounts/password_reset_email.html", success_url=reverse_lazy("accounts:authenticated")), name="password-reset"),
-    path('reset/<uidb64>/<token>/', auth_views.PasswordResetConfirmView.as_view(template_name="accounts/password_reset_confirm.html", success_url=reverse_lazy("accounts:authenticated")), name="password-reset-confirm"),
-    path('register/', register_view, name="register"),
+    path(
+        'login/',
+        auth_views.LoginView.as_view(
+            template_name="accounts/login.html",
+            authentication_form=UserLoginForm
+        ),
+        name="login"
+    ),
+    path(
+        'logout/',
+        auth_views.LogoutView.as_view(
+            template_name="accounts/logout.html"
+        ),
+        name="logout"
+    ),
+    path(
+        'password_change/',
+        auth_views.PasswordChangeView.as_view(
+            template_name="accounts/password_change_form.html",
+            success_url=reverse_lazy("accounts:profile")
+        ),
+        name="password-change"
+    ),
+    path(
+        'password_reset/',
+        auth_views.PasswordResetView.as_view(
+            template_name="accounts/password_reset_form.html",
+            email_template_name="accounts/password_reset_email.html",
+            success_url=reverse_lazy("accounts:reset-done")
+        ),
+        name="password-reset"
+    ),
+    path(
+        'reset/<uidb64>/<token>/',
+        auth_views.PasswordResetConfirmView.as_view(
+            template_name="accounts/password_reset_confirm.html",
+            success_url=reverse_lazy("accounts:reset-complete")
+        ),
+        name="password-reset-confirm"
+    ),
+    path('register/', Register.as_view(), name="register"),
+    path('profile/', Profile.as_view(), name="profile"),
+    path('reset_done/', ResetDone.as_view(), name="reset-done"),
+    path('reset_complete/', ResetComplete.as_view(), name="reset-complete")
 ]

--- a/bug-track/accounts/views.py
+++ b/bug-track/accounts/views.py
@@ -1,66 +1,28 @@
-from django.shortcuts import render, redirect
-from django.contrib.auth import authenticate, login, logout
-from .forms import UserLoginForm, UserRegisterForm
-from django.contrib.auth.forms import UserCreationForm
+from django.shortcuts import redirect
+from django.contrib.auth import login
+from .forms import UserRegisterForm
 from django.views.generic.edit import FormView
 from django.views.generic import TemplateView
 
 
 # Create your views here.
-def login_view(request):
-    next.request.GET.get('next')
-    form = UserLoginForm(request.POST or None)
-    if form.is_valid():
-        username = form.cleaned_data.get("username")
-        password = form.cleaned_data.get("password")
-        user = authenticate(username=username, password=password)
-        login(request, user)
-        if next:
-            return redirect(next)
-        return redirect("core:home")
-
-    return render(request, "accounts/login.html", {"form": form})
-
-
-def register_view(request):
-    form = UserRegisterForm(request.POST or None)
-
-    if form.is_valid():
-        user = form.save(commit=False)
-        password = form.cleaned_data.get('password')
-        user.set_password(password)
-        user.save()
-        new_user = authenticate(username=user.username, password=password)
-        login(request, new_user)
-        return redirect("core:home")
-
-    context = {
-        "form": form,
-    }
-    return render(request, "accounts/register.html", context)
-
-
-def logout_view(request):
-    logout(request)
-    return redirect('core:home')
-
-
-def authenticated_view(request):
-    return render(request, "accounts/authenticated.html", {})
-
-
 class Register(FormView):
-    form_class = UserCreationForm
+    form_class = UserRegisterForm
     template_name = 'accounts/register.html'
 
     def form_valid(self, form):
-        form.save()
-        username = form.cleaned_data.get('username')
-        raw_password = form.cleaned_data.get('password1')
-        user = authenticate(username=username, password=raw_password)
+        user = form.save()
         login(self.request, user)
-        return redirect('core:home')
+        return redirect('accounts:profile')
 
 
 class Profile(TemplateView):
     template_name = "accounts/profile.html"
+
+
+class ResetDone(TemplateView):
+    template_name = "accounts/password_reset_done.html"
+
+
+class ResetComplete(TemplateView):
+    template_name = "accounts/password_reset_complete.html"

--- a/bug-track/core/templates/partials/navbar.html
+++ b/bug-track/core/templates/partials/navbar.html
@@ -26,8 +26,8 @@
                 </a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                     <a class="dropdown-item" href="{% url 'apps:app-create' %}">Create</a>
-                    <a class="dropdown-item" href="{% url 'apps:app-list' %}">List</a>
                     <a class="dropdown-item" href="{% url 'apps:bug-create' %}">Bug Create</a>
+                    <a class="dropdown-item" href="{% url 'apps:app-list' %}">List</a>
                     <a class="dropdown-item" href="{% url 'apps:bug-list' %}">Bug List</a>
                 </div>
             </li>
@@ -37,12 +37,12 @@
                     Account
                 </a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                    <a class="dropdown-item" href="{% url 'accounts:login' %}">login</a>
+                    <a class="dropdown-item" href="{% url 'accounts:profile' %}">profile</a>
+                    <a class="dropdown-item" href="{% url 'accounts:password-change' %}">change pass</a>
                     <a class="dropdown-item" href="{% url 'accounts:logout' %}">logout</a>
                     <a class="dropdown-item" href="{% url 'accounts:register' %}">register</a>
-                    <a class="dropdown-item" href="{% url 'accounts:authenticated' %}">authenticated</a>
-                    <a class="dropdown-item" href="{% url 'accounts:password-change' %}">change pass</a>
-                    <a class="dropdown-item" href="{% url 'accounts:password-reset' %}">change reset</a>
+                    <a class="dropdown-item" href="{% url 'accounts:login' %}">login</a>
+                    <a class="dropdown-item" href="{% url 'accounts:password-reset' %}">pass reset</a>
                 </div>
             </li>
         </ul>


### PR DESCRIPTION
Accounts app had redundant functionality that occurred during the transition to using the auth views from the ordinary function based custom auth. 

In today's pull:
- removed unused views from account views.
- removed unused templates from accounts templates.
- removed those depreciated urls from accounts urls.
- removed depreciated urls from navbar.
- started adding styling to accounts templates.